### PR TITLE
fix(password): setup security

### DIFF
--- a/switchy.sh
+++ b/switchy.sh
@@ -109,13 +109,13 @@ configure_and_start(){
       eval $COMMAND
       echo "------- Enter your Primary WIFI details -----------------"
       read -p 'Primary WIFI SSID: ' primarywifissid
-      read -p 'Primary WIFI Password: ' primarywifissidpassword
-      log "INFO" "Your primarywifissid is ${primarywifissid} and password is ${primarywifissidpassword}"
-      echo "---------------------------------------------------------"
+      read -s -p 'Primary WIFI Password: ' primarywifissidpassword
+      log "INFO" "Your Primary WIFI SSID is ${primarywifissid}"
+      echo "-----------------------------------------------------------"
       echo "------- Enter your Secondary/Fallback WIFI details -------"
       read -p 'Fallback WIFI SSID: ' secondarywifissid
-      read -p 'Fallback WIFI Password: ', secondarywifissidpassword
-      log "INFO" "Your secondarywifissid is ${secondarywifissid} and password is ${secondarywifissidpassword}"
+      read -s -p 'Fallback WIFI Password: ', secondarywifissidpassword
+      log "INFO" "Your Secondary/Fallback WIFI SSID is ${secondarywifissid}"
       echo "-----------------------------------------------------------"
       echo "✅ Saving configurations to ./switchy.conf"
       echo "configured=true" > ./switchy.conf

--- a/switchy.sh
+++ b/switchy.sh
@@ -109,12 +109,16 @@ configure_and_start(){
       eval $COMMAND
       echo "------- Enter your Primary WIFI details -----------------"
       read -p 'Primary WIFI SSID: ' primarywifissid
+      stty -echo
       read -s -p 'Primary WIFI Password: ' primarywifissidpassword
+      stty echo
       log "INFO" "Your Primary WIFI SSID is ${primarywifissid}"
       echo "-----------------------------------------------------------"
       echo "------- Enter your Secondary/Fallback WIFI details -------"
       read -p 'Fallback WIFI SSID: ' secondarywifissid
-      read -s -p 'Fallback WIFI Password: ', secondarywifissidpassword
+      stty -echo
+      read -s -p 'Fallback WIFI Password: ' secondarywifissidpassword
+      stty echo
       log "INFO" "Your Secondary/Fallback WIFI SSID is ${secondarywifissid}"
       echo "-----------------------------------------------------------"
       echo "✅ Saving configurations to ./switchy.conf"


### PR DESCRIPTION
# Changes

For security reasons, by default
- [x] Don't show password onscreen terminal during user input.
- [x] Don't save password on app logs.

Other
- [x] Make `read -s` POSIX compliant.
- [x] Remove extra `,` comma before secondarywifissidpassword input.